### PR TITLE
Add support for joyo kanji 𠮟 (U+20B9F)

### DIFF
--- a/js/kanji.js
+++ b/js/kanji.js
@@ -23,7 +23,7 @@ $(function () {
             }
         }
         for (var i = 0 ; i < str.length ; ++i) {
-            if(/^[\u4e00-\u9faf]|[\ud842\udf9f]+$/.test(str[i])) {
+            if(/^([\u4e00-\u9faf]|[\ud842\udf9f])+$/.test(str[i])) {
                 if (kanji[str[i]] == undefined) {
                     kanji[str[i]] = 1;
                     diff_arr.push(str[i]);

--- a/js/kanji.js
+++ b/js/kanji.js
@@ -7,16 +7,26 @@ $(function () {
 
     var extract = function () {console.log("ok");
         var list = [];
-        var str = $("#text").val();
+        var src_str = $("#text").val();
+        var str = []
         var kanji = {};
-        var diff_str = "";
+        var diff_arr = [];
         var total = 0;
         result_bloc.html("");
+        for (var i = 0; i < src_str.length; i++) {
+            if (/[\ud842]/.test(src_str[i]) && /[\udf9f]/.test(src_str[i+1])) {
+                continue;
+            } else if (/[\udf9f]/.test(src_str[i]) && /[\ud842]/.test(src_str[i-1])) {
+                str.push(src_str[i-1] + src_str[i]);
+            } else {
+                str.push(src_str[i])
+            }
+        }
         for (var i = 0 ; i < str.length ; ++i) {
-            if(/^[\u4e00-\u9faf]+$/.test(str[i])) {
+            if(/^[\u4e00-\u9faf]|[\ud842\udf9f]+$/.test(str[i])) {
                 if (kanji[str[i]] == undefined) {
                     kanji[str[i]] = 1;
-                    diff_str += str[i];
+                    diff_arr.push(str[i]);
                 } else {
                     ++kanji[str[i]];
                 }
@@ -28,15 +38,15 @@ $(function () {
                 list.push([i, kanji[i]]);
             }
         }
-        link_bloc.html(diff_str.length+" different Kanji found<br />");
-        for (i = 0 ; i < diff_str.length ; i++) {
+        link_bloc.html(diff_arr.length+" different Kanji found<br />");
+        for (i = 0 ; i < diff_arr.length ; i++) {
             link_bloc.append($('<a target="_blank">').
-                attr("href", "http://jisho.org/search/"+diff_str[i]+"%20%23kanji").
-                html(diff_str[i]));
+                attr("href", "http://jisho.org/search/"+diff_arr[i]+"%20%23kanji").
+                html(diff_arr[i]));
         }
         if (list.length > 0) {
             link_bloc.append($('<a target="_blank">').
-                attr("href", "http://jisho.org/search/"+diff_str).html("Show all"));
+                attr("href", "http://jisho.org/search/"+diff_arr).html("Show all"));
         }
         link_bloc.append("<hr />");
 


### PR DESCRIPTION
Added support for the character "𠮟", which is part of the 2136 joyo kanji list and was not properly recognized by this script because its codepoint (U+20B9F) was out of range.

To do this, the textarea string proccessing was changed, making "str" an array of characters (since if it was parsed as a string, it would not recognize the "𠮟" character correctly). Consequently, the "diff_str" variable was also changed to "diff_arr" so that the length is calculated correctly in the following functions.